### PR TITLE
Update README.md to correctly escape '#' in 'C#'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Vindinium Starter for C#
+# Vindinium Starter for C&#35;
 
 Code by Mark Tanner
 (put on github by me, ping me for his contact info)


### PR DESCRIPTION
I noticed that title of the readme displayed as "Vindimium Starter for C" rather than "...for C#". I HTML-escaped the hash/sharp so that it displayed correctly.